### PR TITLE
disable block handlers test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
   integration-tests:
     name: Run integration tests
     runs-on: devnet-tracer
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -35,7 +35,7 @@ pub const INTEGRATION_TEST_DIRS: &[&str] = &[
     "remove-then-update",
     "value-roundtrip",
     "int8",
-    "block-handlers",
+    // "block-handlers",
 ];
 
 const IPFS_URI: &str = "https://ch-ipfs.neontest.xyz";


### PR DESCRIPTION
Neon tracer does not support trace_filter method that is needed to run block handlers test