### PR TITLE
Ndev 3235 add auth to graph

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,9 @@ jobs:
           N_CONCURRENT_TESTS: "1"
           NEON_ACCOUNTS: ${{ github.event.client_payload.accounts }}
           SUBGRAPH_NAME: ${{ github.run_id }}
+          API_KEY: "${{ secrets.API_KEY }}"
+          SECURED_GRAPH_NODE_ADMIN_URI: "https://graph-secured.neontest.xyz/deploy"
+          SECURED_IPFS_URI: "https://ipfs-secured.neontest.xyz "
           IPFS_URI: "https://ch-ipfs.neontest.xyz"
           GRAPH_NODE_ADMIN_URI: "https://ch2-graph.neontest.xyz/deploy/"
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       accounts:
+        type: string
+        default: "0x5743d2f08145f4fb7565323da8830f16c1990a26a601ead1013d72b867140f12"
+        required: true
+        description: "Accounts list"
   repository_dispatch:
     types: [integration-tests]
 
@@ -42,12 +46,22 @@ jobs:
 
       - name: Install lld, jq and libpq-dev
         run: sudo apt-get install -y lld jq libpq-dev protobuf-compiler
+      
+      - name: Set accounts list for tests
+        run: |
+          echo "NEON_ACCOUNTS=$(
+            if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+              echo ${{ inputs.accounts }}
+            else
+              echo ${{ github.event.client_payload.accounts }}
+            fi
+          )" >> $GITHUB_ENV
 
       - name: Run integration tests
         uses: actions-rs/cargo@v1
         env:
           N_CONCURRENT_TESTS: "1"
-          NEON_ACCOUNTS: ${{ github.event.client_payload.accounts }}
+          NEON_ACCOUNTS: ${{env.NEON_ACCOUNTS}}
           SUBGRAPH_NAME: ${{ github.run_id }}
           API_KEY: "${{ secrets.API_KEY }}"
           SECURED_GRAPH_NODE_ADMIN_URI: "https://graph-secured.neontest.xyz/deploy"

--- a/tests/integration-tests/neon-auth/abis/Contract.abi
+++ b/tests/integration-tests/neon-auth/abis/Contract.abi
@@ -1,0 +1,33 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "x",
+        "type": "uint16"
+      }
+    ],
+    "name": "Trigger",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "x",
+        "type": "uint16"
+      }
+    ],
+    "name": "emitTrigger",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/tests/integration-tests/neon-auth/package.json
+++ b/tests/integration-tests/neon-auth/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "neon-auth",
+  "version": "0.1.0",
+  "scripts": {
+    "build-contracts": "../../common/build-contracts.sh",
+    "codegen": "graph codegen --skip-migrations",
+    "test": "yarn build-contracts && truffle test --compile-none --network test",
+    "neon": "yarn build-contracts && yarn truffle test --compile-none --network neonlabs",
+    "auth:test": "graph auth $SECURED_GRAPH_NODE_ADMIN_URI $API_KEY",
+    "create:test": "graph create $SUBGRAPH_NAME --node $SECURED_GRAPH_NODE_ADMIN_URI",
+    "deploy:test": "graph deploy $SUBGRAPH_NAME --version-label v0.0.1 --ipfs $SECURED_IPFS_URI --node $SECURED_GRAPH_NODE_ADMIN_URI --headers='{\"Authorization\": \"Bearer '$API_KEY'\"}'"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "0.52.0-alpha-20230628121316-48231a7",
+    "@graphprotocol/graph-ts": "0.31.0",
+    "solc": "^0.8.2"
+  },
+  "dependencies": {
+    "@truffle/contract": "^4.3",
+    "@truffle/hdwallet-provider": "^1.2",
+    "apollo-fetch": "^0.7.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0",
+    "gluegun": "^4.6.1",
+    "truffle": "^5.2"
+  }
+}

--- a/tests/integration-tests/neon-auth/schema.graphql
+++ b/tests/integration-tests/neon-auth/schema.graphql
@@ -1,0 +1,27 @@
+type Foo @entity {
+  id: ID!
+  value: Int!
+}
+
+type Initialize @entity {
+  id: ID!
+  block: BigInt!
+}
+
+type Block @entity {
+  id: ID!
+  number: BigInt!
+  hash: Bytes!
+}
+
+type BlockFromPollingHandler @entity {
+  id: ID!
+  number: BigInt!
+  hash: Bytes!
+}
+
+type BlockFromOtherPollingHandler @entity {
+  id: ID!
+  number: BigInt!
+  hash: Bytes!
+}

--- a/tests/integration-tests/neon-auth/src/mapping.ts
+++ b/tests/integration-tests/neon-auth/src/mapping.ts
@@ -1,0 +1,80 @@
+import { Address, BigInt, ethereum, log } from '@graphprotocol/graph-ts';
+import { Contract, Trigger } from '../generated/Contract/Contract';
+import {
+  BlockFromOtherPollingHandler,
+  BlockFromPollingHandler,
+  Block,
+  Foo,
+  Initialize,
+} from '../generated/schema';
+import { ContractTemplate } from '../generated/templates';
+
+export function handleBlock(block: ethereum.Block): void {
+  log.info('handleBlock {}', [block.number.toString()]);
+  let blockEntity = new Block(block.number.toString());
+  blockEntity.number = block.number;
+  blockEntity.hash = block.hash;
+  blockEntity.save();
+
+  if (block.number == BigInt.fromI32(2)) {
+    ContractTemplate.create(
+      Address.fromString('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+    );
+  }
+}
+
+export function handleBlockPolling(block: ethereum.Block): void {
+  log.info('handleBlockPolling {}', [block.number.toString()]);
+  let blockEntity = new BlockFromPollingHandler(block.number.toString());
+  blockEntity.number = block.number;
+  blockEntity.hash = block.hash;
+  blockEntity.save();
+}
+
+export function handleBlockPollingFromTemplate(block: ethereum.Block): void {
+  log.info('===> handleBlockPollingFromTemplate {}', [block.number.toString()]);
+  let blockEntity = new BlockFromOtherPollingHandler(block.number.toString());
+  blockEntity.number = block.number;
+  blockEntity.hash = block.hash;
+  blockEntity.save();
+}
+
+export function handleTrigger(event: Trigger): void {
+  // We set the value to 0 to test that the subgraph
+  // runs initialization handler before all other handlers
+  if (event.params.x == 1) {
+    let entity = Foo.load('initialize');
+
+    // If the intialization handler is called first
+    // this would set the value to -1 for Foo entity with id 0
+    // If it is not called first then the value would be 0
+    if (entity != null) {
+      entity.value = -1;
+      entity.id = 'initialize';
+      entity.save();
+    }
+  }
+
+  let obj = new Foo(event.params.x.toString());
+  obj.id = event.params.x.toString();
+  obj.value = event.params.x;
+
+  obj.save();
+}
+
+export function initialize(block: ethereum.Block): void {
+  log.info('initialize called at block', [block.number.toString()]);
+  let entity = new Initialize(block.number.toString());
+  entity.id = block.number.toString();
+  entity.block = block.number;
+  entity.save();
+
+  // If initialization handler is called then this would set
+  // the value to 0 for Foo entity with id 0
+  // This is to test that initialization handler is called
+  // before all other handlers
+  let foo = new Foo('initialize');
+  foo.id = 'initialize';
+  foo.value = 0;
+  foo.save();
+}

--- a/tests/integration-tests/neon-auth/subgraph.yaml
+++ b/tests/integration-tests/neon-auth/subgraph.yaml
@@ -1,0 +1,63 @@
+specVersion: 0.0.6
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Contract
+    network: neonlabs
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: Contract
+      startBlock: 247101047
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      entities:
+        - Call
+      eventHandlers:
+        - event: Trigger(uint16)
+          handler: handleTrigger
+      blockHandlers:
+        - handler: handleBlockPolling
+      file: ./src/mapping.ts
+  - kind: ethereum/contract
+    name: BlockHandlerTest
+    network: neonlabs
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: Contract
+      startBlock: 247101047
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      entities:
+        - Call
+      blockHandlers:
+        - handler: handleBlock
+      file: ./src/mapping.ts
+templates:
+  - kind: ethereum/contract
+    name: ContractTemplate
+    network: neonlabs
+    source:
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Gravatar
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      blockHandlers:
+        - handler: handleBlockPollingFromTemplate
+      file: ./src/mapping.ts

--- a/tests/integration-tests/neon-auth/test/test.js
+++ b/tests/integration-tests/neon-auth/test/test.js
@@ -1,0 +1,196 @@
+const path = require("path");
+const execSync = require("child_process").execSync;
+const child_process = require('child_process');
+const { system, patching } = require("gluegun");
+const { createApolloFetch } = require("apollo-fetch");
+
+const assert = require("assert");
+const Contract = artifacts.require("./Contract.sol");
+
+const srcDir = path.join(__dirname, "..");
+const subgraphName = process.env.SUBGRAPH_NAME || "subgraph_neon_auth";
+const indexNodeUrl = process.env.INDEX_NODE_URL || "https://graph-secured.neontest.xyz/index-node/graphql";
+const subgraphUrl = process.env.SUBGRAPH_URL || `https://graph-secured.neontest.xyz/subgraphs/name/${subgraphName}`;
+const subgraphDeployUri = process.env.SECURED_GRAPH_NODE_ADMIN_URI || "https://graph-secured.neontest.xyz/deploy";
+const ipfsUri = process.env.SECURED_IPFS_URI || "https://ipfs-secured.neontest.xyz";
+
+const zeroAddress = "0x0000000000000000000000000000000000000000";
+const templateBlock = 247101047;
+const apikeyErrorMessage = "Sorry, you have supplied an invalid key";
+
+let block = 0;
+let contractInstance;
+
+const fetchSubgraphIndexNode = createApolloFetch({
+  uri: indexNodeUrl
+});
+
+fetchSubgraphIndexNode.use(({ request, options }, next) => {
+  if (!options.headers) {
+    options.headers = {};
+  }
+  options.headers['Authorization'] = `Bearer ${process.env.API_KEY}`;
+  options.headers['Content-Type'] = 'application/json';
+  next();
+});
+
+const fetchSubgraph = createApolloFetch({
+  uri: subgraphUrl
+});
+
+fetchSubgraph.use(({ request, options }, next) => {
+  if (!options.headers) {
+    options.headers = {};
+  }
+  options.headers['Authorization'] = `Bearer ${process.env.API_KEY}`;
+  options.headers['Content-Type'] = 'application/json';
+  next();
+});
+
+const deployGraphBaseCmd = (name) => {
+  createGraphCmd = `graph create ${name} --node ${subgraphDeployUri}`;
+  execSync(createGraphCmd, { createGraphCmd: srcDir, stdio: "inherit" });
+  return `graph deploy ${name} --version-label v0.0.1 --ipfs ${ipfsUri} --node ${subgraphDeployUri}`;
+}
+
+const exec = (cmd) => {
+  try {
+    return execSync(cmd, { cwd: srcDir, stdio: "inherit" });
+  } catch (e) {
+    throw new Error(`Failed to run command \`${cmd}\``);
+  }
+};
+
+const generateBlocks = async (contract) => {
+  let accounts = await web3.eth.getAccounts();
+
+  // connect to the contract and call the function trigger()
+  contractInstance = new web3.eth.Contract(
+    Contract.abi,
+    contract.address
+  );
+
+  // loop and call emitTrigger 10 times
+  for (let i = 0; i < 10; i++) {
+    await contractInstance.methods
+      .emitTrigger(i + 1)
+      .send({ from: accounts[0] });
+  }
+};
+
+const waitForSubgraphToBeSynced = async () =>
+  new Promise((resolve, reject) => {
+    // Wait for 600s
+    let deadline = Date.now() + 600 * 1000;
+
+    // Function to check if the subgraph is synced
+    const checkSubgraphSynced = async () => {
+      try {
+        let result = await fetchSubgraphIndexNode({
+          query: `{
+            indexingStatusForCurrentVersion(subgraphName: "${subgraphName}") {
+              synced
+              health
+            }
+          }`,
+        });
+        if (result.data.indexingStatusForCurrentVersion.synced) {
+          resolve();
+        } else if (result.data.indexingStatusForCurrentVersion.health != "healthy") {
+          reject(new Error("Subgraph is unhealthy"));
+        } else {
+          throw new Error("Reject or retry");
+        }
+      } catch (e) {
+        if (Date.now() > deadline) {
+          reject(new Error("Timed out waiting for the subgraph to be synced"));
+        } else {
+          console.log("Waiting for the subgraph to be synced...");
+          setTimeout(checkSubgraphSynced, 10000);
+        }
+      }
+    };
+
+    // Periodically check whether the subgraph has synced
+    setTimeout(checkSubgraphSynced, 0);
+  });
+
+contract("Contract", (accounts) => {
+  // Deploy the subgraph once before all tests
+  before(async () => {
+    // Deploy the contract
+    const contract = await Contract.deployed();
+
+    // Insert its address into subgraph manifest
+    txhash = Contract.transactionHash;
+    block = (await web3.eth.getTransaction(txhash)).blockNumber;
+
+    for (let i = 0; i < 2; i++) {
+      await patching.replace(
+        path.join(srcDir, "subgraph.yaml"),
+        zeroAddress,
+        contract.address
+      );
+
+      await patching.replace(
+        path.join(srcDir, "subgraph.yaml"),
+        templateBlock,
+        block
+      );
+    }
+
+    await generateBlocks(contract);
+
+    // Authenticate with API key, create and deploy the subgraph
+    exec(`yarn codegen`);
+    exec(`yarn auth:test`);
+    exec(`yarn create:test`);
+    exec(`yarn deploy:test`);
+
+    // Wait for the subgraph to be indexed
+    await waitForSubgraphToBeSynced();
+  });
+
+  it("test query data of the subgraph deployed with auth", async () => {
+    // Also test that multiple block constraints do not result in a graphql error.
+    let result = await fetchSubgraph({
+      query: `{
+        foos(orderBy: value, skip: 1) { id value }
+      }`,
+    });
+
+    expect(result.errors).to.be.undefined;
+    const foos = [];
+    for (let i = 1; i < 11; i++) {
+      foos.push({ id: i.toString(), value: i });
+    }
+
+    expect(result.data).to.deep.equal({
+      foos: foos,
+    });
+  });
+
+  const headers = [
+    undefined,
+    `--headers='{"Authorization": "Bearer wrong-api-key"}'`,
+    `--headers='{"Authorization": "Base ${process.env.API_KEY}"}'`,
+    `--headers='{}'`,
+    `--headers='{"X-API-Key": "${process.env.API_KEY}"}'`,
+    `--headers='{"X-API-Key": "Bearer ${process.env.API_KEY}"}'`,
+  ];
+
+  headers.forEach((header) => {
+    it("test deploy subgraph with invalid api key", async () => {
+      let deployGraphCmd = deployGraphBaseCmd(`wrong-api-key-${subgraphName}`) + header;
+      let output;
+      try {
+        child_process.execSync(deployGraphCmd).toString();
+      } catch (error) {
+        output = error.message.toString();
+      }
+
+      assert(output.includes(apikeyErrorMessage));
+    });
+  });
+
+});

--- a/tests/integration-tests/neon-auth/truffle.js
+++ b/tests/integration-tests/neon-auth/truffle.js
@@ -1,0 +1,56 @@
+require("babel-register");
+require("babel-polyfill");
+
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+
+const neonDevnet = "https://graph-secured.neontest.xyz/solana";
+
+const Web3HttpProvider = require('web3-providers-http');
+const options = {
+  headers: [
+    {
+      name: 'Content-Type',
+      value: 'application/json'
+    },
+    {
+      name: 'Authorization',
+      value: 'Bearer riewikix7EoP5ieR2Rai9theeB6uv3ph'
+    }
+  ],
+};
+
+const provider = new Web3HttpProvider(neonDevnet, options);
+const privateKeys = process.env.NEON_ACCOUNTS.split(",");
+
+module.exports = {
+  contracts_directory: "../../common",
+  migrations_directory: "../../common",
+  contracts_build_directory: "./truffle_output",
+  networks: {
+    test: {
+      host: "localhost",
+      port: process.env.GANACHE_TEST_PORT || 18545,
+      network_id: "*",
+      gas: "100000000000",
+      gasPrice: "1"
+    },
+    neonlabs: {
+      provider: () => {
+        return new HDWalletProvider(
+          privateKeys,
+          provider
+        );
+      },
+      network_id: "*"
+    },
+    networkCheckTimeout: 120000
+  },
+  mocha: {
+    timeout: 600000
+  },
+  compilers: {
+    solc: {
+      version: "0.8.2"
+    }
+  }
+};

--- a/tests/integration-tests/package.json
+++ b/tests/integration-tests/package.json
@@ -4,6 +4,7 @@
     "api-version-v0-0-4",
     "chain-reverts",
     "host-exports",
+    "neon-auth",
     "non-fatal-errors",
     "overloaded-contract-functions",
     "poi-for-failed-subgraph",

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -29,6 +29,7 @@ pub const INTEGRATION_TEST_DIRS: &[&str] = &[
     "api-version-v0-0-4",
     "chain-reverts",
     "host-exports",
+    "neon-auth",
     "non-fatal-errors",
     "overloaded-contract-functions",
     "poi-for-failed-subgraph",


### PR DESCRIPTION
new secured graph uri allows authenticated requests only

We use `https://graph-secured.neontest.xyz/solana` url to fetch network/deploy contracts/check blocks and send txs for the graph tests. All this requests have to contain a header 'Authorization: Bearer <API_KEY>'

expample:
```bash
curl -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer <API_KEY>' -d '{"method":"eth_chainId","params":[],"id":1,"jsonrpc":"2.0"}' https://graph-secured.neontest.xyz/solana
```

To deploy a subgraph using secure urls we have to be authenticated with the command:
```bash
graph auth $SECURED_GRAPH_NODE_ADMIN_URI $API_KEY
```

and also we have to add `--headers='{"Authorization": "Bearer <API_KEY>"}` into deploy subgraph command
```bash
graph deploy $SUBGRAPH_NAME --version-label v0.0.1 --ipfs $SECURED_IPFS_URI --node $SECURED_GRAPH_NODE_ADMIN_URI --headers='{\"Authorization\": \"Bearer '$API_KEY'\"}
```

Test cases to check auth functionality have been added in this pr. We check the following:
- we can do requests to secured url `https://graph-secured.neontest.xyz/solana` with auth header
- we can deploy a subgraph to our graph via secured url with a valid api key (using github secret API_KEY)
- we can request the subgraph(securely deployed as explained above) info via graphql api
- we can not deploy a subgraph to our graph via secured url with an invalid api key

Our old test cases use auth functionality via whitelisted IPs.
